### PR TITLE
add flush_path missing cli argument

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -59,7 +59,7 @@ pipeline:
     image: plugins/docker:17.05
     pull: true
     repo: plugins/s3-cache
-    tags: [ latest, 1.1.0, 1.1, 1 ]
+    tags: [ latest, 1.1.1, 1.1, 1 ]
     secrets: [ docker_username, docker_password ]
     when:
       branch: master

--- a/main.go
+++ b/main.go
@@ -65,6 +65,11 @@ func main() {
 			EnvVar: "PLUGIN_FLUSH_AGE",
 			Value:  "30",
 		},
+		cli.StringFlag{
+			Name:   "flush_path",
+			Usage:  "path to search for flushable cache files",
+			EnvVar: "PLUGIN_FLUSH_PATH",
+		},
 		cli.BoolFlag{
 			Name:   "debug",
 			Usage:  "debug plugin output",


### PR DESCRIPTION
`flush_path` is referenced in the code but not parsed on the command
line. without this option, any attempt to flush old cache files will
always operate against the default path/bucket