### PR TITLE
✨ support aws session token in cli flag; 🐛 fix bug in calling minio-go credentials.NewStaticV4, third argument should be SessionToken;

### DIFF
--- a/main.go
+++ b/main.go
@@ -132,6 +132,11 @@ func main() {
 			EnvVar: "PLUGIN_SECRET_KEY,CACHE_S3_SECRET_KEY,AWS_SECRET_ACCESS_KEY",
 		},
 		cli.StringFlag{
+			Name:   "session-token",
+			Usage:  "s3 session token",
+			EnvVar: "PLUGIN_SESSION_TOKEN,CACHE_S3_SESSION_TOKEN,AWS_SESSION_TOKEN",
+		},
+		cli.StringFlag{
 			Name:   "region",
 			Usage:  "s3 region",
 			EnvVar: "PLUGIN_REGION,CACHE_S3_REGION",
@@ -307,6 +312,7 @@ func s3Storage(c *cli.Context) (storage.Storage, error) {
 		AcceleratedEndpoint: c.String("accelerated-endpoint"),
 		Access:              c.String("access-key"),
 		Secret:              c.String("secret-key"),
+		Token:               c.String("session-token"),
 		Region:              c.String("region"),
 		UseSSL:              useSSL,
 	})

--- a/storage/s3/s3.go
+++ b/storage/s3/s3.go
@@ -19,6 +19,7 @@ type Options struct {
 	Key                 string
 	Secret              string
 	Access              string
+	Token               string
 
 	// us-east-1
 	// us-west-1
@@ -42,7 +43,7 @@ type s3Storage struct {
 func New(opts *Options) (storage.Storage, error) {
 	var creds *credentials.Credentials
 	if len(opts.Access) != 0 && len(opts.Secret) != 0 {
-		creds = credentials.NewStaticV4(opts.Access, opts.Secret, opts.Region)
+		creds = credentials.NewStaticV4(opts.Access, opts.Secret, opts.Token)
 	} else {
 		creds = credentials.NewIAM("")
 


### PR DESCRIPTION
# 0. Overview
* ✨ support aws session token in cli flag
* 🐛 fix bug in calling minio-go credentials.NewStaticV4, third argument should be SessionToken

## 1. Background

### 1.1 ✨ support aws session token in cli flag
aws sdk support session with `AWS_SESSION_TOKEN` environment variables https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html, this change is to support this environment variable as a cli_flag (corporations generally use assume role session for CI/CD for security best practices)

### 1.2 🐛 fix bug in calling minio-go credentials.NewStaticV4, third argument should be SessionToken
there's a bug at this line in [s3/s3.go s3.New](https://github.com/drone-plugins/drone-s3-cache/compare/master...Shuliyey:feature/add_session_token_cli_flag?expand=1#diff-44bbcc9d983da65f32aa64529eb190e2L45) in `s3/s3.go`, looking through source code of [minio-go credentials.NewStaticV4 pkg/credentials/static.go](https://github.com/minio/minio-go/blob/master/pkg/credentials/static.go#L36), the third argument should be `token` (instead of `region`)