### PR TITLE
Pass region with credentials

### DIFF
--- a/storage/s3/s3.go
+++ b/storage/s3/s3.go
@@ -53,7 +53,7 @@ func New(opts *Options) (storage.Storage, error) {
 			return nil, fmt.Errorf("could not connect to %s using IAM role: %w", opts.Endpoint, err)
 		}
 	}
-	client, err := minio.NewWithCredentials(opts.Endpoint, creds, opts.UseSSL, "")
+	client, err := minio.NewWithCredentials(opts.Endpoint, creds, opts.UseSSL, opts.Region)
 
 	if err != nil {
 		return nil, fmt.Errorf("could not connect to %s: %w", opts.Endpoint, err)


### PR DESCRIPTION
The call to `minio.NewWithCredentials` wasn't passing in the region. This wasn't a problem when the region was in the endpoint but after the plugin was modified to gather bucket and region from the endpoint and then set it to the default this issue got identified.

Fixes https://github.com/drone-plugins/drone-s3-cache/issues/63