### PR TITLE
fix: rename env vars for file-credentials

### DIFF
--- a/cmd/drone-s3-cache/config.go
+++ b/cmd/drone-s3-cache/config.go
@@ -127,7 +127,7 @@ func settingsFlags(settings *plugin.Settings) []cli.Flag {
 		&cli.StringFlag{
 			Name:        "file-credentials",
 			Usage:       "path to s3 credentials file",
-			EnvVars:     []string{"PLUGIN_FILE_CREDENTIALS_PATH", "CACHE_FILE_CREDENTIALS_PATH", "AWS_SHARED_CREDENTIALS_FILE"},
+			EnvVars:     []string{"PLUGIN_FILE_CREDENTIALS", "CACHE_FILE_CREDENTIALS", "AWS_SHARED_CREDENTIALS_FILE"},
 			Destination: &settings.S3Options.FileCredentials,
 		},
 		&cli.StringFlag{


### PR DESCRIPTION
### Description

Sorry, didn't fully refactor `file-credentials` from `file-credentials-path`. This makes it so the setting `file_credentials` works so it isn't `file_credentials_path`.

cc @donny-dont 